### PR TITLE
05task3

### DIFF
--- a/04/src/main.tf
+++ b/04/src/main.tf
@@ -15,7 +15,7 @@ module "vpc" {
 # }
 
 module "marketing-vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=282797c08889fb2ab78c1ac69fcd435453df860d"
   env_name       = var.vm_prop.marketing.env_name
   network_id     = module.vpc.vpc_network.id
   subnet_zones   = var.vm_prop.marketing.subnet_zones
@@ -25,6 +25,7 @@ module "marketing-vm" {
   image_family   = var.vm_prop.marketing.image_family
   public_ip      = var.vm_prop.marketing.pub_ip
   labels         = var.vm_prop.marketing.labels
+  security_group_ids = var.security_group_ids
 
 
   metadata = {
@@ -35,7 +36,7 @@ module "marketing-vm" {
 }
 
 module "analytics-vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=282797c08889fb2ab78c1ac69fcd435453df860d"
   env_name       = var.vm_prop.analytics.env_name
   network_id     = module.vpc.vpc_network.id
   subnet_zones   = var.vm_prop.analytics.subnet_zones
@@ -45,6 +46,7 @@ module "analytics-vm" {
   image_family   = var.vm_prop.analytics.image_family
   public_ip      = var.vm_prop.analytics.pub_ip
   labels         = var.vm_prop.analytics.labels
+  security_group_ids = var.security_group_ids
 
   metadata = {
     user-data          = data.template_file.cloudinit.rendered

--- a/04/src/providers.tf
+++ b/04/src/providers.tf
@@ -2,6 +2,11 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = ">= 0.100.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2"
     }
   }
   required_version = ">=0.13"

--- a/04/src/variables.tf
+++ b/04/src/variables.tf
@@ -19,11 +19,6 @@ variable "default_zone" {
   default     = "ru-central1-a"
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
-variable "default_cidr" {
-  type        = list(string)
-  default     = ["10.0.1.0/24"]
-  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
-}
 
 variable "vpc_name" {
   type        = string
@@ -53,20 +48,6 @@ variable "packages" {
   default = []
 }
 
-###example vm_web var
-variable "vm_web_name" {
-  type        = string
-  default     = "netology-develop-platform-web"
-  description = "example vm_web_ prefix"
-}
-
-###example vm_db var
-variable "vm_db_name" {
-  type        = string
-  default     = "netology-develop-platform-db"
-  description = "example vm_db_ prefix"
-}
-
 variable "vm_prop" {
   type = map(object({ env_name=string, subnet_zones=list(string), 
     inst_name=string, inst_count=number, image_family=string, pub_ip=bool,
@@ -80,4 +61,9 @@ variable "subnets" {
   default = [ 
     { zone = "ru-central1-a", cidr = "10.0.1.0/24" } 
   ]
+}
+
+variable "security_group_ids" {
+  type        = list(string)
+  description = "security_group_ids"
 }


### PR DESCRIPTION
docker run --rm -v "$(pwd):/tflint" ghcr.io/terraform-linters/tflint --chdir=/tflint
7 issue(s) found:

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on ../tflint/main.tf line 18:
  18:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_module_pinned_source.md

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on ../tflint/main.tf line 38:
  38:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_module_pinned_source.md

Warning: Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)

  on ../tflint/main.tf line 56:
  56: data "template_file" "cloudinit" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_required_providers.md

Warning: Missing version constraint for provider "yandex" in `required_providers` (terraform_required_providers)

  on ../tflint/providers.tf line 3:
   3:     yandex = {
   4:       source = "yandex-cloud/yandex"
   5:     }

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_required_providers.md

Warning: [Fixable] variable "default_cidr" is declared but not used (terraform_unused_declarations)

  on ../tflint/variables.tf line 22:
  22: variable "default_cidr" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "vm_web_name" is declared but not used (terraform_unused_declarations)

  on ../tflint/variables.tf line 57:
  57: variable "vm_web_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "vm_db_name" is declared but not used (terraform_unused_declarations)

  on ../tflint/variables.tf line 64:
  64: variable "vm_db_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_unused_declarations.md

docker run --rm --tty --volume $(pwd):/tf --workdir /tf bridgecrew/checkov --download-external-modules true --directory /tf


       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By Prisma Cloud | version: 3.2.29 
Update available 3.2.29 -> 3.2.31
Run pip3 install -U checkov to update 


terraform scan results:

Passed checks: 4, Failed checks: 4, Skipped checks: 0

Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
	PASSED for resource: module.analytics-vm.yandex_compute_instance.vm[0]
	File: /.external_modules/github.com/udjin10/yandex_compute_instance/282797c08889fb2ab78c1ac69fcd435453df860d/main.tf:24-73
	Calling File: /main.tf:37-54
Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
	PASSED for resource: module.marketing-vm.yandex_compute_instance.vm[0]
	File: /.external_modules/github.com/udjin10/yandex_compute_instance/282797c08889fb2ab78c1ac69fcd435453df860d/main.tf:24-73
	Calling File: /main.tf:17-35
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
	PASSED for resource: marketing-vm
	File: /main.tf:17-35
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
	PASSED for resource: analytics-vm
	File: /main.tf:37-54
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
	FAILED for resource: module.analytics-vm.yandex_compute_instance.vm[0]
	File: /.external_modules/github.com/udjin10/yandex_compute_instance/282797c08889fb2ab78c1ac69fcd435453df860d/main.tf:24-73
	Calling File: /main.tf:37-54

		Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
	FAILED for resource: module.analytics-vm.yandex_compute_instance.vm[0]
	File: /.external_modules/github.com/udjin10/yandex_compute_instance/282797c08889fb2ab78c1ac69fcd435453df860d/main.tf:24-73
	Calling File: /main.tf:37-54

		Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
	FAILED for resource: module.marketing-vm.yandex_compute_instance.vm[0]
	File: /.external_modules/github.com/udjin10/yandex_compute_instance/282797c08889fb2ab78c1ac69fcd435453df860d/main.tf:24-73
	Calling File: /main.tf:17-35

		Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
	FAILED for resource: module.marketing-vm.yandex_compute_instance.vm[0]
	File: /.external_modules/github.com/udjin10/yandex_compute_instance/282797c08889fb2ab78c1ac69fcd435453df860d/main.tf:24-73
	Calling File: /main.tf:17-35

		Code lines for this resource are too many. Please use IDE of your choice to review the file.


Terraform will perform the following actions:

  # module.analytics-vm.yandex_compute_instance.vm[0] will be updated in-place
  ~ resource "yandex_compute_instance" "vm" {
        id                        = "fhmue591spd48p8sbkel"
        name                      = "develop-analytics-0"
        # (12 unchanged attributes hidden)

      ~ network_interface {
          ~ nat                = true -> false
          ~ security_group_ids = [
              + "enplu4b4g1es4ap43gu8",
            ]
            # (8 unchanged attributes hidden)
        }

        # (5 unchanged blocks hidden)
    }

  # module.marketing-vm.yandex_compute_instance.vm[0] will be updated in-place
  ~ resource "yandex_compute_instance" "vm" {
        id                        = "fhmldh0fcnr99vdtsv6m"
        name                      = "develop-marketing-0"
        # (12 unchanged attributes hidden)

      ~ network_interface {
          ~ nat                = true -> false
          ~ security_group_ids = [
              + "enplu4b4g1es4ap43gu8",
            ]
            # (8 unchanged attributes hidden)
        }

        # (5 unchanged blocks hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.

